### PR TITLE
Fix getNworkers()

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -74,7 +74,7 @@ DESeqParallel <- function(object, test, fitType, betaPrior, full, reduced,
 }
 
 getNworkers <- function(BPPARAM) {
-  nworkers <- BPPARAM$workers
+  nworkers <- bpworkers(BPPARAM)
   if (!nworkers[[1]]) {
     nworkers <- 1 # serial param gives a list with the element FALSE
   }


### PR DESCRIPTION
This wasn't working in the case of `DoparParam()`.

``` r
doParallel::registerDoParallel(5)
BPPARAM <- BiocParallel::DoparParam()
DESeq2:::getNworkers(BPPARAM)  # wrong
#> [1] 1
BiocParallel::bpworkers(BPPARAM)  # correct
#> [1] 5
```

<sup>Created on 2020-11-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>